### PR TITLE
Update usage example

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,9 @@ use sysinfo::{ProcessRefreshKind, RefreshKind, System};
     version,
     about = "Brightness control utility for Hyprland",
     after_help = "Example:
-    hyprlight i 10    # Increase brightness by 10%
+    hyprlight 10 i    # Increase brightness by 10%
     hyprlight d       # Decrease brightness by default step (5%)
-    hyprlight i 5 -q  # Increase brightness by 5% quietly"
+    hyprlight -n 5 i  # Increase brightness by 5% quietly"
 )]
 struct Args {
     #[command(subcommand)]


### PR DESCRIPTION
The usage example showed an inexistent `-q` option, which I assumed means "quiet", so I changed to `-n`.
And the order of the options was reversed